### PR TITLE
add 8ports

### DIFF
--- a/mycspdk/ports8.py
+++ b/mycspdk/ports8.py
@@ -1,0 +1,17 @@
+import gdsfactory as gf
+from cspdk.si220.cband import cells
+
+
+@gf.cell
+def ports8()->gf.Component:
+    c = gf.Component()
+    c.add_polygon([(0, 0), (10, 0), (10, 10), (0, 10)], layer=(1, 0))
+    c.add_port("o1", center=(0, 3), layer=(1, 0), width=1, orientation=180)
+    c.add_port("o2", center=(0, 7), layer=(1, 0), width=1, orientation=180)
+    c.add_port("o3", center=(3, 10), layer=(1, 0), width=1, orientation=90)
+    c.add_port("o4", center=(7, 10), layer=(1, 0), width=1, orientation=90)
+    c.add_port("o5", center=(10, 7), layer=(1, 0), width=1, orientation=0)
+    c.add_port("o6", center=(10, 3), layer=(1, 0), width=1, orientation=0)
+    c.add_port("o7", center=(7, 0), layer=(1, 0), width=1, orientation=270)
+    c.add_port("o8", center=(3, 0), layer=(1, 0), width=1, orientation=270)
+    return c

--- a/mycspdk/ports8_wrapper.pic.yml
+++ b/mycspdk/ports8_wrapper.pic.yml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=../build/schemas/ports8_wrapper.json
+instances:
+  p8:
+    component: ports8
+    settings: {}
+connections: {}
+routes: {}
+nets: []
+ports: {}
+placements:
+  p8:
+    x: 0.0
+    y: 0.0
+    dx: -78.94686126708984
+    dy: -61.379093170166016

--- a/mycspdk/ports8_wrapper.scm.yml
+++ b/mycspdk/ports8_wrapper.scm.yml
@@ -1,0 +1,34 @@
+exploded: ''
+camera_transform:
+  translation:
+    x: 0.0
+    y: 0.0
+    z: 0.0
+  rotation:
+    x: 0.0
+    y: 0.0
+    z: 0.0
+    w: 1.0
+  scale:
+    x: 1.0
+    y: 1.0
+    z: 1.0
+transforms:
+  p8:
+    translation:
+      x: -66.75466
+      y: 51.899994
+      z: 2.0
+    rotation:
+      x: 0.0
+      y: 0.0
+      z: 0.0
+      w: 1.0
+    scale:
+      x: 1.0
+      y: 1.0
+      z: 1.0
+sizes:
+  p8:
+    width: 100
+    height: 100


### PR DESCRIPTION
This is a useful component for debugging purposes.

## Summary by Sourcery

Add a new debugging component ports8 with eight ports and associated Scheme and PIC YAML wrappers for configuration

New Features:
- Introduce ports8 component defining a 10×10 square with eight ports positioned around its edges
- Add ports8_wrapper.scm.yml to specify default transforms and sizes for the ports8 component
- Add ports8_wrapper.pic.yml to configure PIC wrapper instances, placements, and connections for ports8